### PR TITLE
whitelist rango and block scams

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -12,6 +12,7 @@
     "satoshilabs.com"
   ],
   "whitelist": [
+    "rango.exchange",
     "cryptocities.world",
     "metamax.exchange",
     "openmeta.network",
@@ -513,6 +514,7 @@
     "launchpad.ethereum.org"
   ],
   "blacklist": [
+    "rangos-exchange.com",
     "lifeparallel.app",
     "lineasbuild.com",
     "lineabuild.netlify.app",


### PR DESCRIPTION
Using metamask browser on mobile, which uses duckduckgo, our users search for rango exchange but the scam website shows up first and our original website is not shown even until page 10 where I gave up looking. Therefore any user of our platform that uses metamask browser is very likely to end up in the scam website! 
![photo_2023-07-20 11 15 20](https://github.com/georgelombardi97/eth-phishing-detect/assets/106404363/47b9d02c-4e22-459b-970e-0c0a09a5d1a6)
